### PR TITLE
Fix: Image window move when close another image window

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -339,8 +339,9 @@ int main(int argc, const char **argv) {
             ImGui::EndMainMenuBar();
         }
 
-        for (int i = 0; i < image_windows.size(); ++i) {
-            std::shared_ptr<ImageWindow> image_window = image_windows[i];
+        int image_window_index = 0;
+        while (image_window_index < image_windows.size()) {
+            std::shared_ptr<ImageWindow> image_window = image_windows[image_window_index];
 
             // image window
             ImGui::SetNextWindowPos(image_window->computeDefaultPosition(), ImGuiCond_Appearing);
@@ -352,7 +353,7 @@ int main(int argc, const char **argv) {
 
             // check should close
             if (!image_window->is_open) {
-                image_windows.erase(image_windows.begin() + i);
+                image_windows.erase(image_windows.begin() + image_window_index);
                 ImGui::End();
                 continue;
             }
@@ -429,6 +430,8 @@ int main(int argc, const char **argv) {
                         ImGui::GetWindowContentRegionMax().y - ImGui::GetWindowContentRegionMin().y)));
             }
             ImGui::End();
+
+            ++image_window_index;
         }
 
         // rendering

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -353,6 +353,7 @@ int main(int argc, const char **argv) {
             // check should close
             if (!image_window->is_open) {
                 image_windows.erase(image_windows.begin() + i);
+                ImGui::End();
                 continue;
             }
 


### PR DESCRIPTION
Fix #27:
When close an image window, another image window have a chance to move to another location.